### PR TITLE
Catch different protocol format when input source is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,8 +251,9 @@ class ZNRInstance extends InstanceBase {
 							break
 						case 0:
 							const nv = newVal.split(' (')
-							const nn = nv[1].slice(0, -1)
-							rtr.inp[i - 1].name = nv[0]
+              const nn = ('(None)'==nv ? nv : nv[1].slice(0,-1))
+
+              rtr.inp[i - 1].name = nv[0]
 							rtr.inp[i - 1].net = nn
 							this.setVariableValues({ [`${vn}_n`]: nv[0], [`${vn}_t`]: nn })
 					}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zenvideo-ndirouter",
-	"version": "2.4.0",
+	"version": "2.4.1",
 	"type": "module",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Input and Network name response is different when no input is attached/configured.
Fixes #13 